### PR TITLE
Fixed typo on README and quick hotfix on constructor initialization order

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ HsmBase provides an additional option to write a HSM: Derive from HsmBase and im
 
 ## Features of HsmBase
 
-- Type safe, no makros
+- Type safe, no macros
 - Free for commercial and non-commercial use
 - Runs very fast
 - Compiles very fast, even for huge HSMs
@@ -25,7 +25,7 @@ HsmBase provides an additional option to write a HSM: Derive from HsmBase and im
 
 Currently there is no documentation but a tiny example and a unit test.
 
-The general usage is simple: Copy the file src/hsmbase.h to your project. Derive a class from stm::HsmBase which needs two template parameters. The first template parameter is the derived class (google for CRTP if this feels odd to you), the second parameter ist your event type. Then write a method for every leaf state and compound state. Every method contains code for entry/exit actions if needed, a call to transition() to change state and an action which is associated with the transition. Specify the hierarchy of states and the start state in the constructor. Call start on the state machine and feed events into the state machine.
+The general usage is simple: Copy the file src/hsmbase.h to your project. Derive a class from stm::HsmBase which needs two template parameters. The first template parameter is the derived class (google for CRTP if this feels odd to you), the second parameter is your event type. Then write a method for every leaf state and compound state. Every method contains code for entry/exit actions if needed, a call to transition() to change state and an action which is associated with the transition. Specify the hierarchy of states and the start state in the constructor. Call start on the state machine and feed events into the state machine.
 
 TODO
 

--- a/src/hsmbase.h
+++ b/src/hsmbase.h
@@ -53,11 +53,11 @@ class HsmBase
 {
 public:
     HsmBase()
-        : m_nextIndex(2)  //2 places reserved for root and superroot
+        : m_state(0)
         , m_reason(INIT)
+        , m_nextIndex(2)  //2 places reserved for root and superroot
         , m_transitionSeen(false)
         , m_rootSet(false)
-        , m_state(0)
         , m_started(false)
     {
         m_nodes[0].hierarchy=-1;  //super root


### PR DESCRIPTION
Hi,
I just started using your project and noticed a couple of typos in the README plus it didn't compile for me on Windows--I had to change the initialization order in the ctor.